### PR TITLE
build: enable warnings as errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -15,9 +15,17 @@ let package = Package(
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "DBThreadSafe"),
+            name: "DBThreadSafe",
+            swiftSettings: [
+                .treatAllWarnings(as: .error)
+            ]
+        ),
         .testTarget(
             name: "DBThreadSafeTests",
-            dependencies: ["DBThreadSafe"]),
+            dependencies: ["DBThreadSafe"],
+            swiftSettings: [
+                .treatAllWarnings(as: .error)
+            ]
+        ),
     ]
 )

--- a/Tests/DBThreadSafeTests/ThreadSafeTests.swift
+++ b/Tests/DBThreadSafeTests/ThreadSafeTests.swift
@@ -62,9 +62,10 @@ struct ThreadSafeTests {
     @Test("Concurrent reads via wrappedValue")
     func concurrentReads() {
         @ThreadSafe var value = 42
+        let container = $value
 
         DispatchQueue.concurrentPerform(iterations: iterations) { _ in
-            _ = value
+            _ = container.read { $0 }
         }
 
         #expect(value == 42)


### PR DESCRIPTION
## What changed
- enabled `.treatAllWarnings(as: .error)` for the package and test targets
- updated the concurrent read test to avoid the Xcode 26 sendability diagnostic

## Why
This keeps the package warning-free under the latest toolchain and makes new warnings fail fast in CI.